### PR TITLE
skip filtering on status, when not applied - filter_objects

### DIFF
--- a/ghunner/api/helper.py
+++ b/ghunner/api/helper.py
@@ -35,6 +35,9 @@ def filter_objects(
     if filter is None:
         return objects, date_skip
 
+    # if no filter has been applied, return empty
+    # filter list.
+    filter_statuses = []
     if "statuses" in filter_copy:
         filter_statuses = filter_copy["statuses"]
         del filter_copy["statuses"]
@@ -48,7 +51,11 @@ def filter_objects(
                 ):
                     date_skip = True
                     continue
-        if hasattr(general_obj, "status") and hasattr(general_obj, "conclusion"):
+        if (
+            len(filter_statuses) > 0
+            and hasattr(general_obj, "status")
+            and hasattr(general_obj, "conclusion")
+        ):
             status = getattr(general_obj, "status")
             conclusion = getattr(general_obj, "conclusion")
             if status not in filter_statuses and conclusion not in filter_statuses:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ghunner"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Bjørnar Moe Remmen <bjornarremm@gmail.com>"]
 


### PR DESCRIPTION
Added a fix to be able to run this code when "multiple status filtering" is not used.

e.g. --status in-progress --status success